### PR TITLE
Collectd is missing the disk plugin (.so file) on AWS and RH Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -728,6 +728,11 @@ EOF
 		if [ "$?" != 0 ]; then
 			exit_with_failure "Failed to install collectd"
 		fi
+		echo -e "\nyum -y -q install collectd-disk" >>${INSTALL_LOG}
+		yum -y install collectd-disk >>${INSTALL_LOG} 2>&1
+		if [ "$?" != 0 ]; then
+			exit_with_failure "Failed to install collectd-disk"
+		fi
 		echo_success
 		;;
 	esac


### PR DESCRIPTION
This plugin should always be installed. It is by default on other packages but not AWS/RH
yum install collectd-disk
