### PR TITLE
start wavefront-proxy after writing config file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -597,12 +597,6 @@ if [ -n "$INSTALL_PROXY" ]; then
 			exit_with_failure "Failed to install the Wavefront Proxy with APT"
 		fi
 		echo_success
-		echo_step " Starting service"
-		service wavefront-proxy start >>${INSTALL_LOG} 2>&1
-		if [ $? -ne 0 ]; then
-			exit_with_failure "Failed to start the Wavefront Proxy"
-		fi
-		echo_success
 		;;
 	REDHAT)
 		echo_step "Installing Wavefront Proxy (RedHat) with token: $TOKEN for cluster at: $SERVER"; echo


### PR DESCRIPTION
In the case where `$OPERATING_SYSTEM` is `DEBIAN`, the wavefront-proxy was being started before the configuration file was written. Later `service wavefront-proxy start` is run a second time, but this is ignored because the service is already running. The net result is a misconfigured proxy (pointed at try.wavefront.com with no API token).

This change removes the first invocation of `service` in favor of the second one.
